### PR TITLE
Add OpenRouter backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ from agentic_memory.memory_system import AgenticMemorySystem
 # Initialize the memory system 🚀
 memory_system = AgenticMemorySystem(
     model_name='all-MiniLM-L6-v2',  # Embedding model for ChromaDB
-    llm_backend="openai",           # LLM backend (openai/ollama)
+    llm_backend="openai",           # LLM backend (openai/ollama/openrouter)
     llm_model="gpt-4o-mini"         # LLM model name
 )
 
@@ -157,7 +157,7 @@ memory_system.delete(memory_id3)
    - Automatic keyword extraction from content
    - Context generation based on semantic understanding
    - Smart tag assignment for categorization
-   - Seamless integration with OpenAI and Ollama backends
+   - Seamless integration with OpenAI, Ollama, and OpenRouter backends
 
 2. **Enhanced ChromaDB Vector Storage** 📦
    - Embedding generation using content + metadata for superior semantic search
@@ -180,6 +180,7 @@ memory_system.delete(memory_id3)
 5. **Multiple LLM Backends** 🤖
    - OpenAI (GPT-4, GPT-4o-mini, GPT-3.5)
    - Ollama (for local deployment)
+   - OpenRouter (access to 100+ models from multiple providers)
    - Configurable model selection for analysis and evolution
 
 ### Best Practices 💪
@@ -204,8 +205,9 @@ memory_system.delete(memory_id3)
 
 4. **LLM Integration** 🤖:
    - Ensure API keys are properly configured for your chosen backend
-   - Use gpt-4o-mini for cost-effective analysis or gpt-4 for higher quality
-   - Consider Ollama for local deployment and privacy requirements
+   - OpenAI: Use gpt-4o-mini for cost-effective analysis or gpt-4 for higher quality
+   - OpenRouter: Try free models as well as premium models from a vast catalog
+   - Ollama: Consider for local deployment and privacy requirements
    - Monitor LLM usage for cost management
 
 5. **Error Handling** ⚠️:

--- a/agentic_memory/llm_controller.py
+++ b/agentic_memory/llm_controller.py
@@ -9,6 +9,37 @@ class BaseLLMController(ABC):
     def get_completion(self, prompt: str) -> str:
         """Get completion from LLM"""
         pass
+    
+    def _generate_empty_value(self, schema_type: str, schema_items: dict = None) -> Any:
+        """Generate empty value based on JSON schema type."""
+        if schema_type == "array":
+            return []
+        elif schema_type == "string":
+            return ""
+        elif schema_type == "object":
+            return {}
+        elif schema_type == "number":
+            return 0
+        elif schema_type == "boolean":
+            return False
+        return None
+
+    def _generate_empty_response(self, response_format: dict) -> dict:
+        """Generate empty response matching the expected schema."""
+        if "json_schema" not in response_format:
+            return {}
+            
+        schema = response_format["json_schema"]["schema"]
+        result = {}
+        
+        if "properties" in schema:
+            for prop_name, prop_schema in schema["properties"].items():
+                result[prop_name] = self._generate_empty_value(
+                    prop_schema["type"], 
+                    prop_schema.get("items")
+                )
+        
+        return result
 
 class OpenAIController(BaseLLMController):
     def __init__(self, model: str = "gpt-4", api_key: Optional[str] = None):
@@ -40,33 +71,6 @@ class OllamaController(BaseLLMController):
     def __init__(self, model: str = "llama2"):
         from ollama import chat
         self.model = model
-    
-    def _generate_empty_value(self, schema_type: str, schema_items: dict = None) -> Any:
-        if schema_type == "array":
-            return []
-        elif schema_type == "string":
-            return ""
-        elif schema_type == "object":
-            return {}
-        elif schema_type == "number":
-            return 0
-        elif schema_type == "boolean":
-            return False
-        return None
-
-    def _generate_empty_response(self, response_format: dict) -> dict:
-        if "json_schema" not in response_format:
-            return {}
-            
-        schema = response_format["json_schema"]["schema"]
-        result = {}
-        
-        if "properties" in schema:
-            for prop_name, prop_schema in schema["properties"].items():
-                result[prop_name] = self._generate_empty_value(prop_schema["type"], 
-                                                            prop_schema.get("items"))
-        
-        return result
 
     def get_completion(self, prompt: str, response_format: dict, temperature: float = 0.7) -> str:
         try:
@@ -83,18 +87,83 @@ class OllamaController(BaseLLMController):
             empty_response = self._generate_empty_response(response_format)
             return json.dumps(empty_response)
 
+class OpenRouterController(BaseLLMController):
+    """LLM controller for OpenRouter API using litellm.
+    
+    OpenRouter provides access to multiple LLM providers through a unified API.
+    This controller uses litellm to interface with OpenRouter, supporting any model
+    available on the OpenRouter platform.
+    
+    Args:
+        model: Model identifier (e.g., "openai/gpt-4o-mini", "anthropic/claude-3.5-sonnet").
+               The "openrouter/" prefix is automatically added if not present.
+        api_key: OpenRouter API key. If None, reads from OPENROUTER_API_KEY env variable.
+        
+    Raises:
+        ValueError: If API key is not provided and not found in environment.
+    
+    Examples:
+        >>> controller = OpenRouterController("openai/gpt-4o-mini", api_key="your-key")
+        >>> controller = OpenRouterController("google/gemini-2.0-flash-001:free")
+    """
+    
+    def __init__(self, model: str = "openai/gpt-4o-mini", api_key: Optional[str] = None):
+        # For litellm, prepend "openrouter/" if not already present
+        if not model.startswith("openrouter/"):
+            self.model = f"openrouter/{model}"
+        else:
+            self.model = model
+            
+        if api_key is None:
+            api_key = os.getenv('OPENROUTER_API_KEY')
+        if api_key is None:
+            raise ValueError("OpenRouter API key not found. Set OPENROUTER_API_KEY environment variable.")
+        
+        # Set the environment variable for litellm to use
+        os.environ['OPENROUTER_API_KEY'] = api_key
+        self.api_key = api_key
+    
+    def get_completion(self, prompt: str, response_format: dict, temperature: float = 0.7) -> str:
+        """Get completion from OpenRouter API.
+        
+        Args:
+            prompt: The prompt to send to the LLM.
+            response_format: JSON schema specifying the expected response format.
+            temperature: Sampling temperature (0.0 to 1.0).
+            
+        Returns:
+            JSON string containing the LLM response.
+        """
+        try:
+            response = completion(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": "You must respond with a JSON object."},
+                    {"role": "user", "content": prompt}
+                ],
+                response_format=response_format,
+                temperature=temperature
+            )
+            return response.choices[0].message.content
+        except Exception as e:
+            # Silently fall back to empty response on error
+            empty_response = self._generate_empty_response(response_format)
+            return json.dumps(empty_response)
+
 class LLMController:
     """LLM-based controller for memory metadata generation"""
     def __init__(self, 
-                 backend: Literal["openai", "ollama"] = "openai",
+                 backend: Literal["openai", "ollama", "openrouter"] = "openai",
                  model: str = "gpt-4", 
                  api_key: Optional[str] = None):
         if backend == "openai":
             self.llm = OpenAIController(model, api_key)
         elif backend == "ollama":
             self.llm = OllamaController(model)
+        elif backend == "openrouter":
+            self.llm = OpenRouterController(model, api_key)
         else:
-            raise ValueError("Backend must be one of: 'openai', 'ollama'")
+            raise ValueError("Backend must be one of: 'openai', 'ollama', 'openrouter'")
             
     def get_completion(self, prompt: str, response_format: dict = None, temperature: float = 0.7) -> str:
         return self.llm.get_completion(prompt, response_format, temperature)


### PR DESCRIPTION
## Overview
This PR adds support for OpenRouter as a third LLM backend option alongside OpenAI and Ollama, enabling access to 100+ models from multiple providers through a single API.

## Changes
- **New**: `OpenRouterController` class in `llm_controller.py` with comprehensive documentation
- **Refactored**: Moved `_generate_empty_value()` and `_generate_empty_response()` to `BaseLLMController` to eliminate code duplication between Ollama and OpenRouter controllers
- **Updated**: `LLMController` to support `llm_backend="openrouter"` parameter
- **Documentation**: Added OpenRouter usage information and best practices to README

## Key Features
- ✅ Automatic model prefix handling (`openrouter/` prepended automatically)
- ✅ Environment variable support (`OPENROUTER_API_KEY`)
- ✅ Direct API key parameter option
- ✅ Full compatibility with existing A-mem features
- ✅ Graceful fallback on LLM errors (returns empty response)
- ✅ Uses litellm for OpenRouter integration (already a dependency)

## Usage Example
```python
from agentic_memory.memory_system import AgenticMemorySystem
import os

# Initialize with OpenRouter
memory_system = AgenticMemorySystem(
    model_name='all-MiniLM-L6-v2',
    llm_backend="openrouter",
    llm_model="openai/gpt-oss-20b",
    api_key=os.getenv('OPENROUTER_API_KEY')
)

# Use it the same way as OpenAI or Ollama
memory_id = memory_system.add_note("Your content here")
results = memory_system.search("query", k=5)
```

## Testing
Tested successfully with multiple OpenRouter models:
- `openai/gpt-oss-20b`
- `openai/gpt-4o-mini`

All memory operations (add, search, update, delete) work correctly with automatic metadata generation (keywords, tags, context).

## Breaking Changes
None - this is a backwards-compatible addition.

## Additional Notes
- Follows the same pattern as `OllamaController` for consistency
- Refactoring reduces code duplication by moving shared helper methods to base class
- litellm handles all OpenRouter API communication (no new dependencies)